### PR TITLE
Lineup/roster add/drop restrictions 

### DIFF
--- a/FantasyGymnastics/core/templatetags/custom_tags.py
+++ b/FantasyGymnastics/core/templatetags/custom_tags.py
@@ -46,6 +46,10 @@ def get_highest_event_score(score, event):
     return highest
 
 @register.filter
+def event_average(averages, event):
+    return averages.get(event=event)
+    
+@register.filter
 def current_week(lineup, week):
     return lineup.filter(week=week)
 
@@ -54,7 +58,6 @@ def current_week(lineup, week):
     
 @register.filter
 def lineup_score(lineup):
-    print(lineup.event)
     total = 0
     scores = []
     for gymnast in lineup.gymnasts.all():
@@ -92,3 +95,11 @@ def team_score(lineups):
         for score in scores:
             total += score
     return round(total,2)
+
+@register.filter
+def team_has_competed(gymnast, week):
+    gymnasts = Gymnast.objects.filter(team=gymnast.team)
+    if Score.objects.filter(gymnast__in=gymnasts, week=week).exists():
+        return True
+    return False
+

--- a/FantasyGymnastics/core/views.py
+++ b/FantasyGymnastics/core/views.py
@@ -144,7 +144,7 @@ class ViewFantasyTeam(DetailView):
         drafted = context['object'].league.drafted.all()
         context["draftable_gymnasts"] = Gymnast.objects.exclude(id__in=drafted)
         context["lineups"] = LineUp.objects.filter(team=context['object'], week=int(scraper.get_current_and_max_week(ScraperConstants.Men, datetime.now().year)['week'])).order_by('pk')
-        print(context["lineups"])
+        context['averages'] = Average.objects.filter(gymnast__in=context['roster'])
         return context      
 
 class UpdateFantasyTeam(UserPassesTestMixin, UpdateView):

--- a/FantasyGymnastics/templates/core/view_team.html
+++ b/FantasyGymnastics/templates/core/view_team.html
@@ -23,8 +23,10 @@
                         <td>{{gymnast.name}}</td>
                         <td>{{gymnast.team}}</td>
                         <td>{{gymnast.year}}</td>
-                        {% if user == team.user %}
+                        {% if user == team.user and not gymnast|team_has_competed:lineups.all.first.week %}
                         <td><a href="{% url 'remove_gymnast_to_roster' team.pk gymnast.pk %}">X</a></td>
+                        {% else %}
+                        <td></td>
                         {% endif %}
                     </tr>
                     {% endfor %}
@@ -32,11 +34,11 @@
             </table>
             {% comment %} Add to roster button {% endcomment %}
             {% if user == team.user %}
-            {% if team.roster.all.count < team.league.roster_size %} <a class="mb-4"
-                href="{% url 'gymnast_search' team.pk %}"><i class="fas fa-user-plus"></i></a>
-                {% endif %}
-                {% endif %}
-                <p class='mt-4'>{{ team.roster.all.count }}/{{ team.league.roster_size}}</p>
+                {% if team.roster.all.count < team.league.roster_size %} <a class="mb-4"
+                        href="{% url 'gymnast_search' team.pk %}"><i class="fas fa-user-plus"></i></a>
+                    {% endif %}
+            {% endif %}
+            <p class='mt-4'>{{ team.roster.all.count }}/{{ team.league.roster_size}}</p>
         </div>
         <div class="col-md-2"></div>
         {% comment %} Lineups {% endcomment %}
@@ -60,9 +62,12 @@
                     <table class="table table-hover">
                         {% for gymnast in lineup.gymnasts.all %}
                         <tr>
+                            {% comment %} Remove gymnast from lineup {% endcomment %}
                             <td>{{gymnast.name}}</td>
-                            {% if user == team.user %}
+                            {% if user == team.user and not gymnast|team_has_competed:lineup.week %}
                             <td><a href="{% url 'remove_gymnast_from_lineup' lineup.pk gymnast.pk %}">X</a></td>
+                            {% else %}
+                            <td></td>
                             {% endif %}
                         </tr>
                         {% endfor %}
@@ -85,8 +90,12 @@
                                     <table>
                                         {% if user == team.user %}
                                         <tr>
-                                            <td><a
-                                                href="{% url 'add_gymnast_to_lineup' lineup.pk gymnast.pk %}">{{gymnast.name}}</a>
+                                            <td>
+                                                {% if gymnast|team_has_competed:lineup.week %}
+                                                    {{gymnast.name}} AVG:{{averages|from_gymnast:gymnast|event_average:lineup.event}}
+                                                {% else %}
+                                                    <a href="{% url 'add_gymnast_to_lineup' lineup.pk gymnast.pk %}">{{gymnast.name}} AVG:{{averages|from_gymnast:gymnast|event_average:lineup.event}}</a> 
+                                                {% endif %}
                                             </td>
                                         </tr>
                                         {% endif %}

--- a/FantasyGymnastics/templates/weekly_gameplay/view_matchup.html
+++ b/FantasyGymnastics/templates/weekly_gameplay/view_matchup.html
@@ -32,22 +32,25 @@
                         {% for gymnast in lineup.gymnasts.all %}
                             <tr>
                                 {% comment %} Remove from lineup button {% endcomment %}
-                                {% if user == team1.user and matchup.week == current_week %}
+                                {% if user == team1.user and matchup.week == current_week and not gymnast|team_has_competed:lineup.week%}
                                     <td><a href="{% url 'remove_gymnast_from_lineup' lineup.pk gymnast.pk %}">X</a></td>
+                                {% else %}
+                                    <td></td>
                                 {% endif %}
                                 {% comment %} Gymnast name and score for event {% endcomment %}
                                 <td>{{gymnast.name}} </td>
                                 <td>
                                     {% if scores|from_gymnast:gymnast|has_event_score:lineup.event %}
                                         <b>{{ scores|from_gymnast:gymnast|get_highest_event_score:lineup.event }}</b>
+                                    {% elif  gymnast|team_has_competed:lineup.week %}
+                                        <b>0.00</b>
                                     {% else %}
-                                        {% comment %} {% if averages|from_gymnast:gymnast|event_average:lineup.event%}
+                                        {% if averages|from_gymnast:gymnast|event_average:lineup.event%}
                                             <em>{{averages|from_gymnast:gymnast|event_average:lineup.event}}</em>
                                         {% else %}
                                             <em>0.00</em>
-                                        {% endif %} {% endcomment %}
+                                        {% endif %} 
                                     {% endif %}
-                                    
                                 </td>
                             </tr>
                         {% endfor %}
@@ -66,14 +69,19 @@
                     <div class="col">
                         <div class="collapse multi-collapse" id="multiCollapse{{lineup.event}}">
                             {% for gymnast in team1.roster.all %}
-                            {% if gymnast not in lineup.gymnasts.all %}
-                            <table>
-                                <tr>
-                                    <td><a href="{% url 'add_gymnast_to_lineup' lineup.pk gymnast.pk %}">{{gymnast.name}}</a>
-                                    </td>
-                                </tr>
-                            </table>
-                            {% endif %}
+                                {% if gymnast not in lineup.gymnasts.all %}
+                                    <table>
+                                        <tr>
+                                            <td>
+                                                {% if gymnast|team_has_competed:lineup.week %}
+                                                    {{gymnast.name}} AVG:{{averages|from_gymnast:gymnast|event_average:lineup.event}}
+                                                {% else %}
+                                                    <a href="{% url 'add_gymnast_to_lineup' lineup.pk gymnast.pk %}">{{gymnast.name}} AVG:{{averages|from_gymnast:gymnast|event_average:lineup.event}}</a> 
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    </table>
+                                {% endif %}
                             {% endfor %}
                         </div>
                     </div>
@@ -114,13 +122,16 @@
                                 <td>
                                     {% if scores|from_gymnast:gymnast|has_event_score:lineup.event %}
                                         <b>{{ scores|from_gymnast:gymnast|get_highest_event_score:lineup.event }}</b>
+                                    {% elif  gymnast|team_has_competed:lineup.week %}
+                                        <b>0.00</b>
                                     {% else %}
-                                        {% comment %} {% if averages|from_gymnast:gymnast|event_average:lineup.event%}
+                                        {% if averages|from_gymnast:gymnast|event_average:lineup.event%}
                                             <em>{{averages|from_gymnast:gymnast|event_average:lineup.event}}</em>
                                         {% else %}
                                             <em>0.00</em>
-                                        {% endif %} {% endcomment %}
+                                        {% endif %} 
                                     {% endif %}
+                                </td>
                                 <td>{{gymnast.name}} </td>
 
                                 </td>
@@ -134,6 +145,7 @@
                 <tbody>
                     <tr>
                         <td class='alltoleft'>Total {{team2.LineUp.all|current_week:matchup.week|team_score}}</td>
+
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
Can only add/drop gymnasts from lineup/roster if their team hasn't competed that week yet. Also shows averages when selecting gymnasts to put in line up. Also shows gymnasts event average in matchup if their team hasnt competed yet."